### PR TITLE
Use loose template literals to avoid bug in nft

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,20 +1,20 @@
 module.exports = {
-  "plugins": [
+  "assumptions": {
+    "noDocumentAll": true,
+    "pureGetters": true,
+    "iterableIsArray": true,
+    "ignoreToPrimitiveHint": true
+  },
+  "presets": [
     [
-      "@babel/plugin-transform-template-literals",
+      "@babel/preset-env",
       {
-        "loose": true
-      }
-    ]
-  ],
-  'presets': [
-    [
-      '@babel/preset-env',
-      {
-        'targets': {
-          'esmodules': true,
+        "targets": {
+          "esmodules": true,
         },
-      },
+        useBuiltIns: "entry",
+        corejs: "3.25.1"
+      }
     ],
   ],
 };

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,4 +1,12 @@
 module.exports = {
+  "plugins": [
+    [
+      "@babel/plugin-transform-template-literals",
+      {
+        "loose": true
+      }
+    ]
+  ],
   'presets': [
     [
       '@babel/preset-env',


### PR DESCRIPTION
https://github.com/vercel/nft/issues/314

This PR will fix proskomma from breaking next js builds. The option is documented in https://babeljs.io/docs/en/babel-plugin-transform-template-literals#loose . I'm really not familiar with the downsides of using loose but the tests pass just fine. I'm guessing it has potential to break old browser or node versions but I couldn't find details on which ones may be affected. 