### PR TITLE
Stop altChapter from preventing move of Chapter to correct para

### DIFF
--- a/scripts/do_sofria.js
+++ b/scripts/do_sofria.js
@@ -1,0 +1,46 @@
+const fse = require('fs-extra');
+const proskommaUtils = require('proskomma-utils');
+
+const { Proskomma } = require('../dist/index.js');
+
+if (process.argv.length < 3 || process.argv.length > 4) {
+  console.log('USAGE: node do_sofria.js <USFM/USX Path> [chN]');
+  process.exit(1);
+}
+
+const contentPath = process.argv[2];
+let content;
+
+try {
+  content = fse.readFileSync(contentPath);
+} catch (err) {
+  console.log(`ERROR: Could not read from USFM/USX file '${contentPath}'`);
+  process.exit(1);
+}
+
+const contentType = contentPath.split('.').pop();
+let query = `{ documents { sofria${process.argv[3] ? "(chapter: " + process.argv[3] + ")": ""} } }`;
+
+const pk = new Proskomma();
+//try {
+let selectors = {
+  lang: 'lan',
+  abbr: 'myabbr',
+};
+
+pk.importDocument(
+  selectors,
+  contentType,
+  content,
+);
+/*
+} catch (err) {
+console.log(`ERROR: Could not import document: '${err}'\n`);
+console.trace();
+process.exit(1);
+}
+
+ */
+pk.gqlQuery(query)
+  .then(output => console.log(JSON.stringify(JSON.parse(output.data.documents[0].sofria), null, 2)))
+  .catch(err => console.log(`ERROR: Could not run query: '${err}'`));

--- a/src/parser/index.js
+++ b/src/parser/index.js
@@ -153,6 +153,7 @@ const Parser = class {
       seq.addTableScopes();
       seq.close(this);
       this.substitutePubNumberScopes(seq);
+      seq.moveOrphanStartScopes2();
 
       if (seq.type === 'sidebar') {
         this.substituteEsbCatScopes(seq);

--- a/src/parser/model/sequence.js
+++ b/src/parser/model/sequence.js
@@ -203,6 +203,21 @@ const Sequence = class {
     }
   }
 
+  moveOrphanStartScopes2() {
+    for (const [blockNo, block] of this.blocks.entries()) {
+      if (blockNo >= this.blocks.length - 1) {
+        continue;
+      }
+
+      for (const item of [...block.items].reverse()) {
+        if (item.subType !== 'start') {
+          break;
+        }
+        this.blocks[blockNo + 1].items.unshift(this.blocks[blockNo].items.pop());
+      }
+    }
+  }
+
   moveOrphanEndScopes() {
     for (const [blockNo, block] of this.blocks.entries()) {
       if (blockNo === 0) {

--- a/test/code/cp_vp.cjs
+++ b/test/code/cp_vp.cjs
@@ -94,6 +94,7 @@ test(
       const query =
         '{ documents { mainSequence { blocks { items { type subType payload } } } } }';
       const result = await pk2.gqlQuery(query);
+      // console.log(JSON.stringify(result.data, null, 2))
       t.equal(result.errors, undefined);
       const scopes = result.data.documents[0].mainSequence.blocks[0].items.filter(i => i.type === 'scope');
       let count = 0;


### PR DESCRIPTION
This seems to be the cause of a bug in the SOFRIA endpoint when a chapter is specified. The wrong paragraphs are selected because the start-chapter tag is an orphan at the end of the previous paragraph, because it is hiding behind an altChapter tag:

```
Object: null prototype] {
      dump: 'Block:\n' +
        '   title graft to OWIyMTkwOWEt\n' +
        '   Scope blockTag/q\n' +
        '   +chapter/8++verse/1++verses/1++altVerse/2++pubVerse/1 (2)+|Content| |before| |altChapter|.-pubVerse/1 (2)--altVerse/2--verses/1--verse/1--chapter/8-+chapter/9++altChapter/9a+'
    },
    [Object: null prototype] {
      dump: 'Block:\n' +
        '   Scope blockTag/q\n' +
        '   +verse/1++verse/2++verses/1-2++altVerse/2-3++pubVerse/1-2 (2-3)+|First| |verse| |after| |altChapter-pubVerse/1-2 (2-3)--altVerse/2-3--verses/1-2--verse/2--verse/1-'
    }
```
There's a specific exception for altChapter in the parsing code. Bad Things Happen if I remove that, which I think is because of some other scary reordering around pubChapters. So I've made a second, no exception orphan mover that is called after the pubChapters alchemy.

All tests pass.