### PR TITLE
don't return empty verses array from cvIndex type

### DIFF
--- a/src/graph/queries/cvIndex.js
+++ b/src/graph/queries/cvIndex.js
@@ -14,7 +14,7 @@ type cvIndex {
 
 const cvIndexResolvers = {
   chapter: root => root[0],
-  verses: root => root[1],
+  verses: root => root[1].filter(v => v.length > 0),
   verseNumbers: (root, args, context) => {
     context.cvIndex = root;
     return [...root[1].entries()]

--- a/test/code/cv_indexes.cjs
+++ b/test/code/cv_indexes.cjs
@@ -80,13 +80,14 @@ test(
   `cvIndex (${testGroup})`,
   async function (t) {
     try {
-      t.plan(2 + 10 + 6);
+      t.plan(3 + 10 + 6);
       let query =
         `{ documents { cvIndex(chapter:3) ${cvQuery} } }`;
       let result = await pk.gqlQuery(query);
       t.equal(result.errors, undefined);
       let index = result.data.documents[0].cvIndex;
       t.equal(index.chapter, 3);
+      t.equal(index.verses.length, 18);
       checkIndexFields(t, index.verses[1].verse[0]);
       const verseNumbers = result.data.documents[0].cvIndex.verseNumbers;
       t.equal(verseNumbers.length, 18);


### PR DESCRIPTION
In testing I found that querying `verses` on `cvIndex` was returning an empty verse array as the first item. In other places in the codebase, the result of `chapterVerseIndex()` is filtered down to items with length > 0, so I applied that same logic to `cvIndex.verses`.