### PR TITLE
Support Typescript Types

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A Javascript Implementation of the Proskomma Scripture Processing Model.
 # Installing and testing the code
 ```
 npm install
+npm run build
 npm test
 npm run rawTest
 TESTSCRIPT=cp_vp npm run oneTest

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,6 +54,7 @@
         "process": "^0.11.10",
         "tap-summary": "^4.0.0",
         "tape": "^5.6.0",
+        "typescript": "^5.3.3",
         "webpack": "5.74.0",
         "webpack-cli": "4.10.0"
       }
@@ -8254,6 +8255,19 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "node_modules/typescript": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/unbox-primitive": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
@@ -15055,6 +15069,12 @@
       "requires": {
         "is-typedarray": "^1.0.0"
       }
+    },
+    "typescript": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+      "dev": true
     },
     "unbox-primitive": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "rawTest": "tape -r @babel/register test/code/*.cjs",
     "oneTest": "tape -r @babel/register test/code/$TESTSCRIPT.cjs",
     "coverage": "node_modules/nyc/bin/nyc.js tape -r @babel/register test/code/*.cjs",
-    "build": "rm -fr dist && webpack --mode production --config webpack.prod.js",
+    "build": "rm -fr dist && webpack --mode production --config webpack.prod.js && npx tsc",
     "prepublishOnly": "rm -fr dist && npm run build",
     "serialize": "tape -r @babel/register test/code/serialize.cjs"
   },
@@ -41,6 +41,7 @@
     "babel-eslint": "^10.1.0",
     "base64-js": "^1.5.1",
     "bitset": "^5.1.1",
+    "btoa": "^1.2.1",
     "checksum": "^1.0.0",
     "constants-browserify": "^1.0.0",
     "deep-copy-all": "^1.3.4",
@@ -52,13 +53,12 @@
     "path-browserify": "^1.0.1",
     "pipeline-handler": "2.2.0",
     "proskomma-json-tools": "0.6.4",
+    "pure-uuid": "^1.6.2",
     "sax": "^1.2.4",
     "stream": "0.0.2",
     "utf8-string-bytes": "^1.0.3",
     "util": "^0.12.4",
-    "xregexp": "^5.1.1",
-    "pure-uuid": "^1.6.2",
-    "btoa": "^1.2.1"
+    "xregexp": "^5.1.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.18.10",
@@ -73,13 +73,18 @@
     "eslint-plugin-jsdoc": "^39.3.6",
     "eslint-plugin-prettier": "^v4.2.1",
     "fs-extra": "^10.1.0",
-    "path": "0.12.7",
     "nyc": "^15.1.0",
+    "path": "0.12.7",
     "prettier": "^2.7.1",
     "process": "^0.11.10",
     "tap-summary": "^4.0.0",
     "tape": "^5.6.0",
+    "typescript": "^5.3.3",
     "webpack": "5.74.0",
     "webpack-cli": "4.10.0"
+  },
+  "volta": {
+    "node": "20.11.0",
+    "npm": "10.4.0"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "allowJs": true,        // Allow JavaScript files to be compiled.
+    "checkJs": true,        // Enable type checking for JavaScript files.
+    "declaration": true,    // Generate corresponding '.d.ts' file.
+    "emitDeclarationOnly": true, // Only emit '.d.ts' files and no JavaScript output.
+    "outDir": "./dist/types",    // Specify the output directory for '.d.ts' files.
+    "noEmit": false         // Enable emitting files (important for declaration files).
+  },
+  "include": [
+    "src/**/*"              // Adjust this pattern to include your source files.
+  ],
+  "esModuleInterop": true,  // Enable 'esModuleInterop' for compatibility with Babel.
+}


### PR DESCRIPTION
long term its suggested to adopt JSDoc, it's an out of the box documentation platform for javascript that is typescript ready, the same documentation blocks used for JSDoc double as typescript types
